### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/ChefDemo2019/3c47daba-2ebe-44b6-a825-bede899a5ad1/3a60981a-f2f6-415d-8842-fc549c2b76cd/_apis/work/boardbadge/54ab58d2-0475-4038-9d7b-91e9f9f4592c)](https://dev.azure.com/ChefDemo2019/3c47daba-2ebe-44b6-a825-bede899a5ad1/_boards/board/t/3a60981a-f2f6-415d-8842-fc549c2b76cd/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ChefDemo2019/3c47daba-2ebe-44b6-a825-bede899a5ad1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.